### PR TITLE
Fix Poetry config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,6 @@ include = [
     { path = "medusa-example.ini" }
 ]
 
-[project]
-requires-python = ">=3.9.2,<=3.12"
 
 [tool.poetry.scripts]
 medusa = { reference = "medusa.medusacli:cli", type = "console" }


### PR DESCRIPTION
## Summary
- remove `[project]` block from `pyproject.toml` so Poetry can parse it

## Testing
- `poetry check -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6859007b334c832da3644de705a50375